### PR TITLE
Update README with Git LFS, fix local relative paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ Replace `/local/path/to/data` with the path to your input data directory (i.e., 
 
 All the steps below will consider that you cloned this GitHub repository inside your Documents folder.
 There is an examplar raw data under `paper/data/raw` and a processed version using GGIR 3.2-6 under `paper/data/ggir_outputs`.
+If you wish to use this data, be aware that it's stored via Git LFS, so you'll have to run the following commands to download it.
+
+```bash
+git clone https://github.com/childmindresearch/actisleep-tracker.git
+cd actisleep-tracker
+git lfs install
+git lfs pull
+```
 
 After cloning this repository or processing your actigraphy data with GGIR, you should have a folder structure similar to:
 

--- a/src/actigraphy/core/cli.py
+++ b/src/actigraphy/core/cli.py
@@ -50,7 +50,9 @@ def get_subject_folders(args: argparse.Namespace) -> list[str]:
     Returns:
         list[str]: A list of subject folders sorted by name.
     """
-    input_datapath = args.input_folder
+    input_datapath = pathlib.Path(args.input_folder)
+    if not input_datapath.is_absolute():
+        input_datapath = pathlib.Path.cwd() / input_datapath
     return [
         str(directory)
         for directory in sorted(input_datapath.glob("output_*"))

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -26,18 +26,14 @@ def test_parse_args(mocker: plugin.MockerFixture) -> None:
     assert args.verbosity == logging.INFO
 
 
-def test_get_subject_folders(mocker: plugin.MockerFixture) -> None:
+def test_get_subject_folders(tmp_path: pathlib.Path) -> None:
     """Test that get_subject_folders finds all output_ directories."""
-    mocked_path = mocker.MagicMock()
-    mocked_subfolder = mocker.MagicMock()
-    mocked_subfolder.is_dir.return_value = True
-    mocked_subfolder.__str__.return_value = "output_test"
-    mocked_path.glob.return_value = [mocked_subfolder]
-    args = argparse.Namespace(input_folder=mocked_path)
+    (tmp_path / "output_test").mkdir()
+    args = argparse.Namespace(input_folder=str(tmp_path))
 
     result = cli.get_subject_folders(args)
 
-    assert result == ["output_test"]
+    assert result[0] == str(tmp_path / "output_test")
 
 
 def test__add_string_quotation_string() -> None:


### PR DESCRIPTION
* Updated `input_datapath` to use `pathlib.Path` for better path manipulation. The function now checks if the input path is absolute and, if not, resolves it relative to the current working directory.
* Updated the README to instruct users to download the Git LFS files