### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,6 @@
 name: Python Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/childmindresearch/actisleep-tracker/security/code-scanning/14](https://github.com/childmindresearch/actisleep-tracker/security/code-scanning/14)

The best fix is to explicitly declare a `permissions:` block at the root of the workflow to apply least-privilege settings to all jobs not defining their own `permissions`. For most test/CI workflows, only `contents: read` is needed (allows reading repository contents but not writing). If a job needs more permissions (for example, uploading pull request comments), escalate only the minimum necessary at that job. In the provided snippet, nothing performs repository writes, so setting `permissions: contents: read` at the root minimizes risk and satisfies the warning.

**Implementation:**  
- Edit `.github/workflows/test.yaml`.
- Insert a `permissions:` block at line 2, after the `name:` line and before the `on:` block.  
- The block should be:
  ```yaml
  permissions:
    contents: read
  ```
- No new imports, methods, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
